### PR TITLE
feat: Add quotes for Allie and D.B. Caulfield

### DIFF
--- a/characters.py
+++ b/characters.py
@@ -56,7 +56,7 @@ characters_data = [
             "D.B. Caulfield": "Older brother.",
             "Phoebe Caulfield": "Younger sister."
         },
-        "quotes": [],
+        "quotes": ["He wrote poems on his baseball glove in green ink so he'd have something to read when he was in the field and nobody was up at bat. (Described by Holden)"],
         "first_appearance_context": "Through Holden's memories and the English composition he writes about Allie's baseball glove."
     },
     {
@@ -68,7 +68,7 @@ characters_data = [
             "Allie Caulfield": "Deceased younger brother.",
             "Phoebe Caulfield": "Younger sister."
         },
-        "quotes": [],
+        "quotes": ["What I thought about all this stuff I just finished telling you about? (Paraphrased from Holden's account of D.B. asking him)"],
         "first_appearance_context": "Mentioned by Holden early in the novel when discussing his family and his dislike for Hollywood."
     },
     {


### PR DESCRIPTION
I reviewed characters with empty quote lists and added attributable text:
- For Allie Caulfield, I added a description of his poetic baseball mitt, as narrated by Holden.
- For D.B. Caulfield, I added a paraphrased quote of him asking Holden's thoughts on his story.

This enhances the information available for these characters in the dashboard. I reviewed other characters with previously empty quote lists, and no suitable direct quotes were found, so they retain the "No specific quotes noted" status.