### PR TITLE
feat: Add images and enhance visuals for character dashboard

### DIFF
--- a/catcher_dashboard.py
+++ b/catcher_dashboard.py
@@ -16,81 +16,93 @@ def display_character_info(character):
     Args:
         character (dict): A dictionary containing the data for a single character.
     """
-    st.header(character["name"]) # Character's name as a main header
+    # Columns for image and name
+    col1, col2 = st.columns([1, 3]) # Image column is 1/4, text column is 3/4
+
+    with col1:
+        if "image_url" in character and character["image_url"]:
+            st.image(character["image_url"], width=150) # Adjusted width for column
+        # else:
+        #     st.caption("Image not available.") # Optional
+
+    with col2:
+        st.header(character["name"]) # Character's name
+
+    st.divider() # Divider after the header/image row
+
+    with st.container():
+        st.subheader("🌟 Significance")
+        st.markdown(character["significance"])
     st.divider()
 
-    # Display Significance
-    st.subheader("🌟 Significance")
-    st.markdown(character["significance"])
+    with st.container():
+        st.subheader("✨ Key Traits")
+        if character["traits"]:
+            st.markdown("""<style>
+                           .trait-badge {
+                               background-color: #f0f2f6;
+                               border-radius: 5px;
+                               padding: 0.2em 0.6em;
+                               margin: 0.2em 0.3em;
+                               display: inline-block;
+                               font-weight: normal;
+                               border: 1px solid #e0e0e0;
+                               transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+                           }
+                           .trait-badge:hover {
+                               transform: scale(1.05);
+                               box-shadow: 0px 2px 5px rgba(0,0,0,0.1);
+                           }
+                           </style>""", unsafe_allow_html=True)
+            traits_html = "".join([f'<span class="trait-badge">{trait}</span>' for trait in character["traits"]])
+            st.markdown(traits_html, unsafe_allow_html=True)
+        else:
+            st.markdown("No specific traits noted.")
     st.divider()
 
-    # Display Key Traits
-    st.subheader("✨ Key Traits")
-    if character["traits"]:
-        # For a more "tag-like" feel with markdown, we can try this:
-        # traits_md = " ".join([f"**`{trait}`**" for trait in character["traits"]])
-        # Or a slightly simpler bold list:
-        # traits_md = ""
-        # for trait in character["traits"]:
-        #    traits_md += f"- **{trait}**\n"
-        # Let's go with the simpler bold list for now for broader compatibility and readability.
-        st.markdown("""<style>
-                       .trait-badge {
-                           background-color: #f0f2f6;
-                           border-radius: 5px;
-                           padding: 0.2em 0.6em;
-                           margin: 0.2em 0.3em;
-                           display: inline-block;
-                           font-weight: normal;
-                           border: 1px solid #e0e0e0;
-                       }
-                       </style>""", unsafe_allow_html=True)
-        traits_html = "".join([f'<span class="trait-badge">{trait}</span>' for trait in character["traits"]])
-        st.markdown(traits_html, unsafe_allow_html=True)
-    else:
-        st.markdown("No specific traits noted.")
+    with st.container():
+        st.subheader("🤝 Relationships")
+        if character["relationships"]:
+            for name, description in character["relationships"].items():
+                with st.expander(f"**{name}**"):
+                    st.markdown(description)
+        else:
+            st.markdown("No specific relationships noted.")
     st.divider()
 
-    # Display Relationships
-    st.subheader("🤝 Relationships")
-    if character["relationships"]:
-        for name, description in character["relationships"].items():
-            with st.expander(f"**{name}**"): # Use expander for each relationship
-                st.markdown(description)
-    else:
-        st.markdown("No specific relationships noted.")
+    with st.container():
+        st.subheader("💬 Memorable Quotes")
+        if character["quotes"]:
+            st.markdown("""<style>
+                           .custom-quote {
+                               border-left: 5px solid #007bff; /* Blue left border */
+                               background-color: #f9f9f9; /* Light grey background */
+                               padding: 10px 20px;
+                               margin: 10px 0px;
+                               font-style: italic;
+                               color: #333;
+                               border-radius: 5px;
+                               box-shadow: 0px 2px 5px rgba(0,0,0,0.05);
+                           }
+                           .custom-quote p {
+                               margin: 0;
+                           }
+                           </style>""", unsafe_allow_html=True)
+            for i, quote in enumerate(character["quotes"]):
+                st.markdown(f'<div class="custom-quote"><p>"{quote}"</p></div>', unsafe_allow_html=True)
+        else:
+            st.markdown("No specific quotes noted for this character.")
     st.divider()
 
-    # Display Memorable Quotes
-    st.subheader("💬 Memorable Quotes")
-    if character["quotes"]:
-        st.markdown("""<style>
-                       .custom-quote {
-                           border-left: 5px solid #007bff; /* Blue left border */
-                           background-color: #f9f9f9; /* Light grey background */
-                           padding: 10px 20px;
-                           margin: 10px 0px;
-                           font-style: italic;
-                           color: #333;
-                       }
-                       .custom-quote p {
-                           margin: 0;
-                       }
-                       </style>""", unsafe_allow_html=True)
-        for i, quote in enumerate(character["quotes"]):
-            # Using a more robust way to ensure paragraph styling within the quote
-            st.markdown(f'<div class="custom-quote"><p>"{quote}"</p></div>', unsafe_allow_html=True)
-            # Removed the <br> as margins on .custom-quote should handle spacing
-    else:
-        st.markdown("No specific quotes noted for this character.")
-    st.divider()
-
-    # Display First Appearance Context
-    st.subheader("🗺️ First Appearance Context")
-    st.markdown(character["first_appearance_context"])
+    with st.container():
+        st.subheader("🗺️ First Appearance Context")
+        st.markdown(character["first_appearance_context"])
     # No divider after the last section typically
 
 # --- Main Dashboard App ---
+
+# Add a banner image
+st.image("https://via.placeholder.com/800x200/007bff/FFFFFF?Text=Catcher+In+The+Rye+Banner", use_column_width=True)
 
 # Set the main title of the dashboard
 st.title("The Catcher in the Rye: Character Explorer")

--- a/characters.py
+++ b/characters.py
@@ -1,6 +1,7 @@
 characters_data = [
     {
         "name": "Holden Caulfield",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "The protagonist and narrator of the novel, a teenager grappling with adolescence, identity, and the perceived phoniness of the adult world.",
         "traits": [
             "Disillusioned", "Cynical", "Critical of 'phonies'",
@@ -33,6 +34,7 @@ characters_data = [
     },
     {
         "name": "Phoebe Caulfield",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's younger sister, she is intelligent, innocent, and one of the few characters Holden genuinely connects with and respects.",
         "traits": ["Intelligent", "Perceptive", "Innocent but not naive", "Caring", "Direct", "Youthful wisdom"],
         "relationships": {
@@ -49,6 +51,7 @@ characters_data = [
     },
     {
         "name": "Allie Caulfield",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's deceased younger brother, who died of leukemia. Allie represents lost innocence and perfection in Holden's mind.",
         "traits": ["Intelligent", "Kind", "Red-haired", "Wrote poems on his baseball glove"],
         "relationships": {
@@ -61,6 +64,7 @@ characters_data = [
     },
     {
         "name": "D.B. Caulfield",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's older brother, a talented writer who now works in Hollywood, which Holden views as a form of selling out.",
         "traits": ["Talented writer", "Successful (in Hollywood terms)"],
         "relationships": {
@@ -73,6 +77,7 @@ characters_data = [
     },
     {
         "name": "Ward Stradlater",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's roommate at Pencey Prep. He is handsome and popular but also arrogant and a 'secret slob' in Holden's eyes.",
         "traits": ["Handsome", "Athletic", "Popular", "Arrogant", "Superficial", "Secret slob"],
         "relationships": {
@@ -84,6 +89,7 @@ characters_data = [
     },
     {
         "name": "Jane Gallagher",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "A girl from Holden's past whom he remembers fondly and respects. She represents a more innocent and genuine connection for Holden.",
         "traits": ["Innocent (in Holden's view)", "Thoughtful (kept her kings in the back row)", "Had a difficult home life"],
         "relationships": {
@@ -95,6 +101,7 @@ characters_data = [
     },
     {
         "name": "Sally Hayes",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "A girl Holden has dated before and meets up with in New York. She is attractive and conventional, but Holden ultimately finds her superficial.",
         "traits": ["Attractive", "Conventional", "Superficial (in Holden's view)", "Articulate"],
         "relationships": {
@@ -105,6 +112,7 @@ characters_data = [
     },
     {
         "name": "Mr. Antolini",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's former English teacher, who is one of the few adults Holden initially respects and seeks advice from. The visit ends awkwardly.",
         "traits": ["Intelligent", "Concerned for Holden", "Offers academic and life advice"],
         "relationships": {
@@ -117,6 +125,7 @@ characters_data = [
     },
     {
         "name": "Sunny",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "A young prostitute whom Holden hires through Maurice but then only wants to talk to, highlighting his loneliness and confusion about sex.",
         "traits": ["Young", "Business-like", "Seems uninterested in conversation"],
         "relationships": {
@@ -128,6 +137,7 @@ characters_data = [
     },
     {
         "name": "Maurice",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "The elevator operator at the Edmont Hotel who also acts as a pimp. He cheats Holden out of money and assaults him.",
         "traits": ["Intimidating", "Dishonest", "Aggressive"],
         "relationships": {
@@ -139,6 +149,7 @@ characters_data = [
     },
     {
         "name": "Robert Ackley",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's pimply and insecure next-door neighbor at Pencey Prep. Holden finds him annoying but also pities him at times.",
         "traits": ["Insecure", "Poor hygiene", "Intrusive", "Annoying", "Lonely"],
         "relationships": {
@@ -149,6 +160,7 @@ characters_data = [
     },
     {
         "name": "Mr. Spencer",
+        "image_url": "https://via.placeholder.com/150/0000FF/FFFFFF?Text=Character",
         "significance": "Holden's elderly history teacher at Pencey Prep who tries to give Holden a lecture about his future after failing him.",
         "traits": ["Elderly", "Well-meaning but somewhat out of touch with Holden", "Concerned about Holden's academic failure"],
         "relationships": {


### PR DESCRIPTION
This commit introduces several enhancements to the Catcher in the Rye Character Explorer:

1.  **Character Images:**
    - Added an `image_url` field to each character in `characters.py`, using placeholder images for now.
    - The dashboard now displays the image of the selected character in a column next to their name.

2.  **Dashboard Aesthetics:**
    - Added a banner image to the top of the dashboard.
    - Used `st.columns` to refine the layout of character information (image and name).
    - Wrapped content sections in `st.container` for better structure.

3.  **Visual Effects (CSS):**
    - Enhanced trait badges with hover effects (scaling and box shadow).
    - Improved styling for memorable quotes with rounded borders and a subtle box shadow.

These changes aim to make the dashboard more visually engaging and user-friendly.